### PR TITLE
Update to 26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-* Update to 26.1.2
+* Update to 26.2

--- a/common/src/main/java/nx/pingwheel/common/CommonClient.java
+++ b/common/src/main/java/nx/pingwheel/common/CommonClient.java
@@ -59,7 +59,7 @@ public class CommonClient {
 		}
 
 		if (KEY_BINDING_SETTINGS.consumeClick()) {
-			Game.setScreen(new SettingsScreen());
+			Game.gui.setScreen(new SettingsScreen());
 		}
 	}
 

--- a/common/src/main/java/nx/pingwheel/common/command/ClientCommandBuilder.java
+++ b/common/src/main/java/nx/pingwheel/common/command/ClientCommandBuilder.java
@@ -61,7 +61,7 @@ public class ClientCommandBuilder {
 
 		var cmdConfig = LiteralArgumentBuilder.<S>literal("config")
 			.executes((context) -> {
-				Game.schedule(() -> Game.setScreen(new SettingsScreen()));
+				Game.schedule(() -> Game.gui.setScreen(new SettingsScreen()));
 				return 1;
 			});
 

--- a/common/src/main/java/nx/pingwheel/common/core/PingView.java
+++ b/common/src/main/java/nx/pingwheel/common/core/PingView.java
@@ -3,7 +3,6 @@ package nx.pingwheel.common.core;
 import lombok.Getter;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec2;
@@ -81,7 +80,7 @@ public class PingView extends PingData {
 			final var ent = GameContext.getEntity(this.entityId);
 
 			if (ent != null) {
-				if (ent.getType() == EntityType.ITEM && CLIENT_CONFIG.isItemIconVisible()) {
+				if (ent instanceof ItemEntity && CLIENT_CONFIG.isItemIconVisible()) {
 					this.itemStack = ((ItemEntity)ent).getItem().copy();
 				}
 
@@ -139,12 +138,10 @@ public class PingView extends PingData {
 
 	public int getTeamColor() {
 		if (this.playerInfo == null || this.playerInfo.getTeam() == null) return WHITE;
-		if (this.playerInfo == null) return WHITE;
 
-		final var teamColor = this.playerInfo.getTeam().getColor().getColor();
-		if (teamColor == null) return WHITE;
-
-		return (255 << 24) | teamColor;
+		return this.playerInfo.getTeam().getColor()
+			.map(teamColor -> (255 << 24) | teamColor.rgb())
+			.orElse(WHITE);
 	}
 
 	private void calculateScale() {

--- a/common/src/main/java/nx/pingwheel/common/mixin/GameRendererMixin.java
+++ b/common/src/main/java/nx/pingwheel/common/mixin/GameRendererMixin.java
@@ -1,10 +1,8 @@
 package nx.pingwheel.common.mixin;
 
-import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.state.GameRenderState;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
@@ -33,13 +31,8 @@ public abstract class GameRendererMixin {
 	@Shadow protected abstract void bobHurt(CameraRenderState cameraState, PoseStack poseStack);
 	@Shadow protected abstract void bobView(CameraRenderState cameraState, PoseStack poseStack);
 
-	@Inject(method = "extractGui", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;extractRenderState(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V"), remap = false)
-	public void extractGui(DeltaTracker deltaTracker,
-						   boolean shouldRenderLevel,
-						   boolean resourcesLoaded,
-						   CallbackInfo ci,
-						   @Local(name = "graphics") GuiGraphicsExtractor graphics
-	) {
+	@Inject(method = "extract", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;extractRenderState(Lnet/minecraft/client/DeltaTracker;ZZ)V"), remap = false)
+	public void extract(DeltaTracker deltaTracker, boolean advanceGameTime, CallbackInfo ci) {
 		var cameraState = this.gameRenderState.levelRenderState.cameraRenderState;
 		var projectionMatrix = PingWheel_calculateProjectionMatrix(cameraState, deltaTracker);
 
@@ -51,16 +44,6 @@ public abstract class GameRendererMixin {
 				cameraState
 			)
 		);
-
-		if (this.minecraft.options.hideGui) {
-			return;
-		}
-
-		final var matrixStack = graphics.pose();
-		matrixStack.pushMatrix();
-		CommonClient.INSTANCE.onRenderGUI(graphics, deltaTracker.getGameTimeDeltaPartialTick(false));
-
-		matrixStack.popMatrix();
 	}
 
 	@Unique

--- a/common/src/main/java/nx/pingwheel/common/mixin/GuiMixin.java
+++ b/common/src/main/java/nx/pingwheel/common/mixin/GuiMixin.java
@@ -1,0 +1,46 @@
+package nx.pingwheel.common.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import nx.pingwheel.common.CommonClient;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Gui.class)
+public abstract class GuiMixin {
+
+	@Shadow @Final private Minecraft minecraft;
+
+	@Inject(
+		method = "extractRenderState",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/client/gui/Hud;extractRenderState(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V",
+			shift = At.Shift.AFTER
+		),
+		remap = false
+	)
+	private void extractRenderState(
+		DeltaTracker deltaTracker,
+		boolean shouldRenderLevel,
+		boolean resourcesLoaded,
+		CallbackInfo ci,
+		@Local(name = "graphics") GuiGraphicsExtractor graphics
+	) {
+		if (this.minecraft.gui.hud.isHidden()) {
+			return;
+		}
+
+		final var matrixStack = graphics.pose();
+		matrixStack.pushMatrix();
+		CommonClient.INSTANCE.onRenderGUI(graphics, deltaTracker.getGameTimeDeltaPartialTick(false));
+		matrixStack.popMatrix();
+	}
+}

--- a/common/src/main/java/nx/pingwheel/common/render/DrawContext.java
+++ b/common/src/main/java/nx/pingwheel/common/render/DrawContext.java
@@ -1,6 +1,5 @@
 package nx.pingwheel.common.render;
 
-import com.mojang.blaze3d.opengl.GlStateManager;
 import lombok.Getter;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.multiplayer.PlayerInfo;
@@ -54,10 +53,8 @@ public class DrawContext {
 
 	public void renderPlayerHead(PlayerInfo player) {
 		var texture = player.getSkin().body().texturePath();
-		GlStateManager._enableBlend();
 		guiGraphics.blit(RenderPipelines.GUI_TEXTURED, texture, 0, 0, 8, 8, 8, 8, 64, 64);
 		guiGraphics.blit(RenderPipelines.GUI_TEXTURED, texture, 0, 0, 40, 8, 8, 8, 64, 64); // Overlay (hat)
-		GlStateManager._disableBlend();
 	}
 
 	public void renderPing(ItemStack itemStack, boolean drawItemIcon, int color) {
@@ -85,7 +82,6 @@ public class DrawContext {
 	public void renderTexture(Identifier texture, int size, int color) {
 		final var offset = size / -2;
 
-		GlStateManager._enableBlend();
 		guiGraphics.blit(
 			RenderPipelines.GUI_TEXTURED,
 			texture,
@@ -99,7 +95,6 @@ public class DrawContext {
 			size,
 			color
 		);
-		GlStateManager._disableBlend();
 	}
 
 	public void renderArrowIcon(int color) {

--- a/common/src/main/java/nx/pingwheel/common/screen/OptionUtils.java
+++ b/common/src/main/java/nx/pingwheel/common/screen/OptionUtils.java
@@ -22,7 +22,7 @@ public class OptionUtils {
 				.xmap((value) -> value * step, (value) -> value / step, true),
 			Codec.intRange(min, max),
 			getter.get(),
-			setter
+			setter::accept
 		);
 	}
 
@@ -38,7 +38,7 @@ public class OptionUtils {
 				.xmap((value) -> value * step, (value) -> (int) (value / step), true),
 			Codec.floatRange(iMin, iMax),
 			getter.get(),
-			setter
+			setter::accept
 		);
 	}
 
@@ -46,7 +46,7 @@ public class OptionUtils {
 		return OptionInstance.createBoolean(
 			key,
 			getter.get(),
-			setter
+			setter::accept
 		);
 	}
 
@@ -60,7 +60,7 @@ public class OptionUtils {
 				Enum::name
 			)),
 			getter.get(),
-			setter
+			setter::accept
 		);
 	}
 }

--- a/common/src/main/java/nx/pingwheel/common/screen/SettingsScreen.java
+++ b/common/src/main/java/nx/pingwheel/common/screen/SettingsScreen.java
@@ -89,7 +89,7 @@ public class SettingsScreen extends OptionsSubScreen {
 		ClientConfig.HANDLER.save();
 
 		if (parent != null && this.minecraft != null) {
-			this.minecraft.setScreen(parent);
+			this.minecraft.gui.setScreen(parent);
 		} else {
 			super.onClose();
 		}

--- a/common/src/main/resources/pingwheel.mixins.json
+++ b/common/src/main/resources/pingwheel.mixins.json
@@ -4,7 +4,8 @@
 	"package": "nx.pingwheel.common.mixin",
 	"compatibilityLevel": "JAVA_17",
 	"client": [
-		"GameRendererMixin"
+		"GameRendererMixin",
+		"GuiMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,12 +14,12 @@ link_issues=https://github.com/LukenSkyne/Minecraft-Ping-Wheel/issues
 mod_version=1.12.1
 
 # Minecraft
-minecraft_version=26.1.2
+minecraft_version=26.2
 java_version=25
 
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=26.1.2-1
+neo_form_version=26.2-1
 
 # ModDevGradle
 # https://projects.neoforged.net/neoforged/moddevgradle
@@ -27,26 +27,26 @@ mod_dev_gradle_version=2.0.141
 
 # Fabric
 # https://fabricmc.net/develop/
-fabric_version=0.145.4+26.1.2
-fabric_loader_version=0.18.4
-fabric_compatible_range=>=26.1 <=26.1.2
-loom_version=1.15-SNAPSHOT
+fabric_version=0.154.2+26.2
+fabric_loader_version=0.19.3
+fabric_compatible_range=26.2
+loom_version=1.17-SNAPSHOT
 
 # Forge
 # https://files.minecraftforge.net/net/minecraftforge/forge/
 net.minecraftforge.gradle.merge-source-sets=true
-forge_version=64.0.0
+forge_version=65.0.5
 forge_loader_version=62
-forge_compatible_range=[26.1,26.1.2]
+forge_compatible_range=[26.2]
 
 # NeoForge
 # https://projects.neoforged.net/neoforged/neoforge
-neoforge_version=26.1.0.1-beta
+neoforge_version=26.2.0.15-beta
 neoforge_loader_version=1
-neoforge_compatible_range=[26.1,26.1.2]
+neoforge_compatible_range=[26.2]
 
 # Integrations
-modmenu_api_version=18.0.0-alpha.8
+modmenu_api_version=20.0.1
 distanthorizons_api_version=5.1.0
 voicechat_api_version=2.6.0
 ftbteams_version=6930910

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Port Ping Wheel from Minecraft 26.1.2 to 26.2.  Adapted GUI rendering mixins and other changed APIs.

I have tested the build of this version on my own Minecraft server. It works well.